### PR TITLE
Remove /var/run files on uninstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,11 @@ ifneq ($(BRIDGED),)
 	rm -f "$(DESTDIR)/Library/LaunchDaemons/io.github.lima-vm.socket_vmnet.bridged.$(BRIDGED).plist"
 endif
 
-uninstall: uninstall.launchd.plist uninstall.bin
+.PHONY: uninstall.run
+uninstall.run:
+	rm -f /var/run/socket_vmnet*
+
+uninstall: uninstall.launchd.plist uninstall.bin uninstall.run
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
**Before:**
```
$ sudo make uninstall
$ ls -l /var/run | grep socket_vmnet
srwxrwx---  1 root          staff           0 Nov  1 15:13 socket_vmnet
-rw-r--r--  1 root          staff           0 Nov  1 15:13 socket_vmnet.stderr
-rw-r--r--  1 root          staff           0 Nov  1 15:13 socket_vmnet.stdout
```

**After:**
```
$ sudo make uninstall
$ ls -l /var/run | grep socket_vmnet
```