### PR TITLE
Fix the bug with linked list removal.

### DIFF
--- a/main.c
+++ b/main.c
@@ -113,12 +113,12 @@ static void state_remove_socket_fd(struct state *state, int socket_fd) {
   dispatch_semaphore_wait(state->sem, DISPATCH_TIME_FOREVER);
   if (state->conns != NULL) {
     if (state->conns->socket_fd == socket_fd) {
-      state->conns = NULL;
+      state->conns = state->conns->next;
     } else {
       struct conn *conn;
       for (conn = state->conns; conn->next != NULL; conn = conn->next) {
         if (conn->next->socket_fd == socket_fd) {
-          conn->next = NULL;
+          conn->next = conn->next->next;
         }
       }
     }


### PR DESCRIPTION
I was seeing some instability with my testing of running multiple lima VMs when using the guest-to-guest networking and was seeing that connections would effectively just stop working at seemingly random points.

I think the current code has a bug with removing of the sockets because if the first matching entry is the one we're removing, then we effectively remove all of them. If it's a later entry, we effectively remove all the remaining ones by setting the next to NULL instead of the the possible next entry.

I'm also curious about the malloc on Line 98, I didn't see a corresponding free for it, so I'm curious if there's a leak here too. If that's the case, I'd be happy to take a crack at it, but first wanted to see about this fix.

Caveat: It's been probably over a decade since I used c so I may have missed something :)

Signed-off-by: Ville Aikas <vaikas@chainguard.dev>