### PR TITLE
Fix segv when removing the last socket entry.

### DIFF
--- a/main.c
+++ b/main.c
@@ -119,6 +119,7 @@ static void state_remove_socket_fd(struct state *state, int socket_fd) {
       for (conn = state->conns; conn->next != NULL; conn = conn->next) {
         if (conn->next->socket_fd == socket_fd) {
           conn->next = conn->next->next;
+	  break;
         }
       }
     }


### PR DESCRIPTION
Fix the case of removing the last socket. Previous patch missed this case.

We've fixed the pointers, so just break out of the loop.

Signed-off-by: Ville Aikas <vaikas@chainguard.dev>