### PR TITLE
Remove write on sockets that return EOF (0 bytes). 

### DIFF
--- a/main.c
+++ b/main.c
@@ -489,6 +489,10 @@ static void on_accept(struct state *state, int accept_fd, interface_ref iface) {
       perror("read");
       goto done;
     }
+    if (received == 0) {
+      // EOF according to man page of read.
+      goto done;
+    }
     assert(received == header);
     DEBUGF("[Socket-to-VMNET i=%lld] Received from the socket %d: %ld bytes", i,
            accept_fd, received);


### PR DESCRIPTION
While debugging the socket issues and running in debug mode, I noticed that there were spurious errors when you perform things like spin up two VMs and then stop one. Looking at the `read` man page looks like 0 means the file has been closed so if that's the case, just be done with socket.

on_accept(): vmnet_return_t VMNET_INVALID_ARGUMENT
vmnet_write: Undefined error: 0

Signed-off-by: Ville Aikas <vaikas@chainguard.dev>