### PR TITLE
Update the log path (`var/run/socket_vmnet.stdout` -> `var/log/socket_vmnet/stdout`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ Default configuration:
 Config  | Value
 --------|--------------------------------------------------
 Socket  | `${HOMEBREW_PREFIX}/var/run/socket_vmnet`
-Stdout  | `${HOMEBREW_PREFIX}/var/run/socket_vmnet.stdout`
-Stderr  | `${HOMEBREW_PREFIX}/var/run/socket_vmnet.stderr`
+Stdout  | `${HOMEBREW_PREFIX}/var/log/socket_vmnet/stdout`
+Stderr  | `${HOMEBREW_PREFIX}/var/log/socket_vmnet/stderr`
 Gateway | 192.168.105.1
 
 To uninstall the launchd service:
@@ -139,8 +139,8 @@ Default configuration:
 Config  | Value
 --------|--------------------------------------------------
 Socket  | `/var/run/socket_vmnet`
-Stdout  | `/var/run/socket_vmnet.stdout`
-Stderr  | `/var/run/socket_vmnet.stderr`
+Stdout  | `/var/log/socket_vmnet/stdout`
+Stderr  | `/var/log/socket_vmnet/stderr`
 Gateway | 192.168.105.1
 
 
@@ -290,4 +290,5 @@ You do not need to configure (and you can't, currently) the MAC address of `sock
 
 ## Troubleshooting
 - Set environment variable `DEBUG=1`
-- See `${HOMEBREW_PREFIX}/var/run/socket_vmnet.{stdout,stderr}` (when using launchd)
+- See `${HOMEBREW_PREFIX}/var/log/socket_vmnet/{stdout,stderr}` (when using launchd).
+  The path was previously `${HOMEBREW_PREFIX}/var/run/socket_vmnet.{stdout,stderr}` until March 2023.

--- a/launchd/io.github.lima-vm.socket_vmnet.bridged.en0.plist
+++ b/launchd/io.github.lima-vm.socket_vmnet.bridged.en0.plist
@@ -15,9 +15,9 @@
 			<string>/var/run/socket_vmnet.bridged.en0</string>
 		</array>
 		<key>StandardErrorPath</key>
-		<string>/var/run/socket_vmnet.bridged.en0.stderr</string>
+		<string>/var/log/socket_vmnet/bridged.en0.stderr</string>
 		<key>StandardOutPath</key>
-		<string>/var/run/socket_vmnet.bridged.en0.stdout</string>
+		<string>/var/log/socket_vmnet/bridged.en0.stdout</string>
 		<key>RunAtLoad</key>
 		<true />
 		<key>UserName</key>

--- a/launchd/io.github.lima-vm.socket_vmnet.plist
+++ b/launchd/io.github.lima-vm.socket_vmnet.plist
@@ -14,9 +14,9 @@
 			<string>/var/run/socket_vmnet</string>
 		</array>
 		<key>StandardErrorPath</key>
-		<string>/var/run/socket_vmnet.stderr</string>
+		<string>/var/log/socket_vmnet/stderr</string>
 		<key>StandardOutPath</key>
-		<string>/var/run/socket_vmnet.stdout</string>
+		<string>/var/log/socket_vmnet/stdout</string>
 		<key>RunAtLoad</key>
 		<true />
 		<key>UserName</key>


### PR DESCRIPTION
Homebrew changed the log path today (March 17, 2023): https://github.com/Homebrew/homebrew-core/commit/36e27de7891670a833487bba7062f10d7949297c