### PR TITLE
Fix to include correct Availability.h header

### DIFF
--- a/cli.c
+++ b/cli.c
@@ -5,7 +5,7 @@
 #include <arpa/inet.h>
 #include <getopt.h>
 
-#include <availability.h>
+#include <Availability.h>
 #include <uuid/uuid.h>
 
 #include "cli.h"


### PR DESCRIPTION
I believe I have discovered a very peculiar bug related to header names. First, a little background. The default filesystem on macOS Is a case-insensitive, case-preserving filesystem. This means that two files sharing the same case-insensitive name cannot exist in the same directory. For example, a directory cannot contain a filed named Test.txt and test.txt; they are, in fact, the same file. This is evident from the output of the "stat" command:

```
% stat -f %i Test.txt
28557750
% stat -f %i test.txt
28557750
```

HFS and APFS can optionally be configured in a case-sensitive mode. Unlike the default case-insensitive, case-preserving mode, the file "Test.txt" and "test.txt" are uniquely separate inodes. If you have access to a case-sensitive filesystem, give it a try.

Now, I discovered that while packaging socket_vmnet for MacPorts, the port compiled successfully on my local system, but failed to compile on the MacPorts build systems. Thanks to some very clever MacPorts developers, it was disclosed that the MacPorts build systems use case-sensitive filesystems.

In `cli.c`, line 8, includes "availability.h". In actuality, the OS X SDK includes a file named "Availability.h" (not "availability.h"). On case-insensitive, case-preserving filesystems, this incorrect #include statement inadvertently still works due to the case-insensitivity. But it fails on case-sensitive filesystems.

This PR edits the #include statement to include the file name as it is declared in the SDK: Availability.h.