### PR TITLE
Keep the launchd daemon alive

### DIFF
--- a/launchd/io.github.lima-vm.socket_vmnet.bridged.en0.plist
+++ b/launchd/io.github.lima-vm.socket_vmnet.bridged.en0.plist
@@ -20,6 +20,8 @@
 		<string>/var/log/socket_vmnet/bridged.en0.stdout</string>
 		<key>RunAtLoad</key>
 		<true />
+		<key>KeepAlive</key>
+		<true />
 		<key>UserName</key>
 		<string>root</string>
 	</dict>

--- a/launchd/io.github.lima-vm.socket_vmnet.plist
+++ b/launchd/io.github.lima-vm.socket_vmnet.plist
@@ -19,6 +19,8 @@
 		<string>/var/log/socket_vmnet/stdout</string>
 		<key>RunAtLoad</key>
 		<true />
+		<key>KeepAlive</key>
+		<true />
 		<key>UserName</key>
 		<string>root</string>
 	</dict>


### PR DESCRIPTION
Working with multiple lima clusters in the recent weeks I found that socket_vmnet is not running for unknown reason. The typical flow is trying to start the clusters, and lima hostagent fails with connection refused with /var/run/socket_vmnet. This happens to me one or more times in the same day. Trying to run a stress test creating and destroying the lima clusters 50 times fails after several runs and from the point of the failure, all runs failed.

The issue seems to be that socket_vmnet is stopped by launched because it seems to be idle and it is never started again. Adding the keep alive option eliminated this issue.

With this change the daemon is kept running and it should restart after failures.