### PR TITLE
CI: remove macos-11; update Lima etc.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: macos-11
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # https://github.com/reproducible-containers/repro-get/issues/3
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
       - 'master'
 jobs:
   release:
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Test (shared mode)
         run: ./test/test.sh /var/run/socket_vmnet
 # Bridged mode cannot be tested on GHA
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: 1.20.x
       - name: Install Lima

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,12 +48,12 @@ jobs:
 # Bridged mode cannot be tested on GHA
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.20.x
+          go-version: 1.23.x
       - name: Install Lima
         run: |
           git clone https://github.com/lima-vm/lima
           cd lima
-          git checkout v0.17.0
+          git checkout v0.23.2
           make
           sudo make install
           limactl sudoers >etc_sudoers.d_lima

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,10 @@ jobs:
     name: Integration tests
     strategy:
       matrix:
-        # macos-13-xl is used as macos-13 seems too flaky
-        platform: [macos-11, macos-12, macos-13-xl]
+        # macos-13-large is used as macos-13 seems too flaky.
+        # macos-14 (ARM) cannot be used for the most part of the job
+        # due to the lack of the support for nested virt.
+        platform: [macos-12, macos-13-large]
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 40
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 40
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Show host info


### PR DESCRIPTION
macos-11 is no longer available
https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/