### PR TITLE
Ignore SIGPIPE, handle EPIPE

### DIFF
--- a/main.c
+++ b/main.c
@@ -399,7 +399,9 @@ int main(int argc, char *argv[]) {
   signal(SIGHUP, signalhandler);
   signal(SIGINT, signalhandler);
   signal(SIGTERM, signalhandler);
-  signal(SIGPIPE, signalhandler);
+
+  // We will receive EPIPE on the socket.
+  signal(SIGPIPE, SIG_IGN);
 
   int pid_fd = -1;
   if (cliopt->pidfile != NULL) {


### PR DESCRIPTION
We get this signal when writing to a socket when the other side closed the connection. This is wrong since this is not a fatal error. The right way to handle SIGPIPE is to ignore it and handle EPIPE when writing to socket, which we already do.

Fixes: #48