### PR TITLE
Fix incorrect getgrnam error handling

### DIFF
--- a/main.c
+++ b/main.c
@@ -348,6 +348,7 @@ static int socket_bindlisten(const char *socket_path,
     goto err;
   }
   if (socket_group != NULL) {
+    errno = 0;
     struct group *grp = getgrnam(socket_group); /* Do not free */
     if (grp == NULL) {
       if (errno != 0)


### PR DESCRIPTION
getgrent(3) says:

    Note that programs must explicitly set errno to zero before calling any
    of these functions if they need to distinguish between a non-existent
    entry and an error.

We didn't so we could log the wrong error based on previous failed call and confuse the user.