### PR TITLE
Fix "IP address is not assigned" troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ You do not need to configure (and you can't, currently) the MAC address of `sock
 ### IP address is not assigned
 Try the following commands:
 ```console
-/usr/libexec/ApplicationFirewall/socketfilterfw --add /usr/libexec/bootpd
+sudo /usr/libexec/ApplicationFirewall/socketfilterfw --add /usr/libexec/bootpd
 /usr/libexec/ApplicationFirewall/socketfilterfw --unblock /usr/libexec/bootpd
 ```
 


### PR DESCRIPTION
The first "succeeds" without sudo:

    % /usr/libexec/ApplicationFirewall/socketfilterfw --add /usr/libexec/bootpd
    Application at path ( /usr/libexec/bootpd ) added to firewall

But then the next command fails:

    % /usr/libexec/ApplicationFirewall/socketfilterfw --unblock /usr/libexec/bootpd
    The application is not part of the firewall

Running the first command with sudo works:

    % sudo /usr/libexec/ApplicationFirewall/socketfilterfw --add /usr/libexec/bootpd
    Application at path ( /usr/libexec/bootpd ) added to firewall

    % /usr/libexec/ApplicationFirewall/socketfilterfw --unblock /usr/libexec/bootpd
    Incoming connection to the application is permitted

It looks like Apple bug, the first command should fail if the application was not added to the firewall.