### PR TITLE
Fix error handling when connection closed by peer

### DIFF
--- a/main.c
+++ b/main.c
@@ -486,6 +486,11 @@ static void on_accept(struct state *state, int accept_fd, interface_ref iface) {
       perror("read[header]");
       goto done;
     }
+    if (header_received == 0) {
+      // EOF according to man page of read.
+      fprintf(stderr, "Connection closed by peer (fd %d)\n", accept_fd);
+      goto done;
+    }
     uint32_t header = ntohl(header_be);
     assert(header <= buf_len);
     ssize_t received = read(accept_fd, buf, header);
@@ -495,6 +500,7 @@ static void on_accept(struct state *state, int accept_fd, interface_ref iface) {
     }
     if (received == 0) {
       // EOF according to man page of read.
+      fprintf(stderr, "Connection closed by peer (fd %d)\n", accept_fd);
       goto done;
     }
     assert(received == header);


### PR DESCRIPTION
We checked for zero read when reading the packet but not when reading the header, so we tried to read zero bytes from the closed socket (which succeeds), and then tried to write zero length packet to vmnet, which fails with VMNET_INVALID_ARGUMENT:

Example logs (from my logging branch):

    ERROR| accept: Interrupted system call
    ERROR| vmnet_write: [1003] VMNET_INVALID_ARGUMENT
    INFO | Closing a connection (fd 5)
    ERROR| writev: Bad file descriptor
    ERROR| writev: Bad file descriptor
    ERROR| vmnet_write: [1003] VMNET_INVALID_ARGUMENT
    INFO | Closing a connection (fd 6)

Now we check for zero read and log a clear message:

    Connection closed by peer (fd 5)