### PR TITLE
Run socket_vmnet as interactive process

### DIFF
--- a/launchd/io.github.lima-vm.socket_vmnet.bridged.en0.plist
+++ b/launchd/io.github.lima-vm.socket_vmnet.bridged.en0.plist
@@ -24,5 +24,8 @@
 		<true />
 		<key>UserName</key>
 		<string>root</string>
+		<!-- Avoid resource limits harming performance -->
+		<key>ProcessType</key>
+		<string>Interactive</string>
 	</dict>
 </plist>

--- a/launchd/io.github.lima-vm.socket_vmnet.plist
+++ b/launchd/io.github.lima-vm.socket_vmnet.plist
@@ -23,5 +23,8 @@
 		<true />
 		<key>UserName</key>
 		<string>root</string>
+		<!-- Avoid resource limits harming performance -->
+		<key>ProcessType</key>
+		<string>Interactive</string>
 	</dict>
 </plist>


### PR DESCRIPTION
According to launchd.plist(5), if ProcessType is left unspecified, the system will apply light resource limits to the job, throttling its CPU usage and I/O bandwidth. Turns out that these resource limits cause lower and unpredictable performance.

Testing ProcessType Interactive increase iperf3 throughput from 1.32 to 3.59 Gbit/s (2.71 times faster).

Before:

    % iperf3-darwin -c 192.168.105.58
    Connecting to host 192.168.105.58, port 5201
    [  5] local 192.168.105.1 port 50333 connected to 192.168.105.58 port 5201
    [ ID] Interval           Transfer     Bitrate         Retr  Cwnd          RTT
    [  5]   0.00-1.00   sec   158 MBytes  1.32 Gbits/sec    0   2.91 MBytes   21ms
    [  5]   1.00-2.00   sec   163 MBytes  1.36 Gbits/sec    0   3.05 MBytes   19ms
    [  5]   2.00-3.00   sec   152 MBytes  1.28 Gbits/sec    0   3.15 MBytes   19ms
    [  5]   3.00-4.00   sec   167 MBytes  1.40 Gbits/sec    0   3.23 MBytes   21ms
    [  5]   4.00-5.00   sec   162 MBytes  1.36 Gbits/sec    0   3.29 MBytes   21ms
    [  5]   5.00-6.00   sec   151 MBytes  1.27 Gbits/sec    0   3.34 MBytes   21ms
    [  5]   6.00-7.00   sec   160 MBytes  1.34 Gbits/sec    0   3.36 MBytes   20ms
    [  5]   7.00-8.00   sec   152 MBytes  1.28 Gbits/sec    0   3.38 MBytes   22ms
    [  5]   8.00-9.00   sec   161 MBytes  1.35 Gbits/sec    0   3.38 MBytes   23ms
    [  5]   9.00-10.00  sec   152 MBytes  1.27 Gbits/sec    0   3.39 MBytes   21ms
    - - - - - - - - - - - - - - - - - - - - - - - - -
    [ ID] Interval           Transfer     Bitrate         Retr
    [  5]   0.00-10.00  sec  1.54 GBytes  1.32 Gbits/sec    0             sender
    [  5]   0.00-10.00  sec  1.54 GBytes  1.32 Gbits/sec                  receiver

After:

    % iperf3-darwin -c 192.168.105.58
    Connecting to host 192.168.105.58, port 5201
    [  5] local 192.168.105.1 port 50415 connected to 192.168.105.58 port 5201
    [ ID] Interval           Transfer     Bitrate         Retr  Cwnd          RTT
    [  5]   0.00-1.00   sec   453 MBytes  3.80 Gbits/sec    0   8.00 MBytes   10ms
    [  5]   1.00-2.00   sec   426 MBytes  3.57 Gbits/sec    0   8.00 MBytes   9ms
    [  5]   2.00-3.00   sec   422 MBytes  3.54 Gbits/sec    0   8.00 MBytes   9ms
    [  5]   3.00-4.00   sec   405 MBytes  3.40 Gbits/sec    0   8.00 MBytes   9ms
    [  5]   4.00-5.00   sec   429 MBytes  3.60 Gbits/sec    0   8.00 MBytes   9ms
    [  5]   5.00-6.00   sec   433 MBytes  3.64 Gbits/sec    0   8.00 MBytes   9ms
    [  5]   6.00-7.00   sec   432 MBytes  3.62 Gbits/sec    0   8.00 MBytes   10ms
    [  5]   7.00-8.00   sec   432 MBytes  3.63 Gbits/sec    0   8.00 MBytes   9ms
    [  5]   8.00-9.00   sec   414 MBytes  3.47 Gbits/sec    0   8.00 MBytes   9ms
    [  5]   9.00-10.00  sec   433 MBytes  3.63 Gbits/sec    0   8.00 MBytes   9ms
    - - - - - - - - - - - - - - - - - - - - - - - - -
    [ ID] Interval           Transfer     Bitrate         Retr
    [  5]   0.00-10.00  sec  4.18 GBytes  3.59 Gbits/sec    0             sender
    [  5]   0.00-10.01  sec  4.18 GBytes  3.59 Gbits/sec                  receiver

Testing with 2 vms is much slower and tend to get stuck because of #39.