### PR TITLE
CI: fix `Kernel panic - not syncing: IO-APIC + timer doesn't work!`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
         run: brew install iperf3 jq
       - name: "Lima: vm1: prepare"
         run: |
-          limactl start --name=vm1 --set '.cpus=1 | .memory = "1GiB"' --tty=false template://vmnet
+          limactl start --name=vm1 --set '.cpus=1 | .memory = "1GiB"' --tty=false ./test/vmnet.yaml
           limactl shell vm1 ip a
       - name: "Lima: vm1: set up iperf3"
         run: |
@@ -81,7 +81,7 @@ jobs:
         run: tail -n500 ~/.lima/vm1/*.log
       - name: "Lima: vm2: prepare"
         run: |
-          limactl start --name=vm2  --set '.cpus=1 | .memory = "1GiB"' --tty=false template://vmnet
+          limactl start --name=vm2  --set '.cpus=1 | .memory = "1GiB"' --tty=false ./test/vmnet.yaml
           limactl shell vm2 ip a
       - name: "Lima: vm2: set up iperf3"
         run: |

--- a/test/vmnet.yaml
+++ b/test/vmnet.yaml
@@ -1,0 +1,22 @@
+# Forked from https://github.com/lima-vm/lima/blob/v0.23.2/examples/vmnet.yaml
+#
+# `no_timer_check` is injected to the kernel cmdline, as a workaround to https://github.com/lima-vm/lima/issues/84
+
+images:
+- location: "https://cloud-images.ubuntu.com/releases/24.04/release-20240821/ubuntu-24.04-server-cloudimg-amd64.img"
+  arch: "x86_64"
+  digest: "sha256:0e25ca6ee9f08ec5d4f9910054b66ae7163c6152e81a3e67689d89bd6e4dfa69"
+  kernel:
+    location: https://cloud-images.ubuntu.com/releases/24.04/release-20240821/unpacked/ubuntu-24.04-server-cloudimg-amd64-vmlinuz-generic
+    digest: sha256:1e894dc26a939a7cb408ba8366e101f5572a5f85a90a6d74ab4cb55211460306
+    cmdline: root=LABEL=cloudimg-rootfs ro console=tty1 console=ttyAMA0 no_timer_check
+  initrd:
+    location: https://cloud-images.ubuntu.com/releases/24.04/release-20240821/unpacked/ubuntu-24.04-server-cloudimg-amd64-initrd-generic
+    digest: sha256:c44215c42d97abd9ada4a961de0ab7305d74c39860776cf2d7a0260ac9d0637e
+
+mounts:
+- location: "~"
+- location: "/tmp/lima"
+  writable: true
+networks:
+- lima: shared


### PR DESCRIPTION
Inject `no_timer_check` to the kernel cmdline as a workaround to lima-vm/lima issue 84 on GitHub Actions.

Fix #55