### PR TITLE
Update instructions to use -netdev stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,13 +208,12 @@ sudo make PREFIX=/opt/socket_vmnet uninstall.launchd
 ## Usage
 
 ### QEMU
-Make sure that the `socket_vmnet` daemon is running, and execute QEMU via `socket_vmnet_client` as follows:
+Make sure that the `socket_vmnet` daemon is running, and execute QEMU as follows:
 
 ```console
-${HOMEBREW_PREFIX}/opt/socket_vmnet/bin/socket_vmnet_client \
-  ${HOMEBREW_PREFIX}/var/run/socket_vmnet \
-  qemu-system-x86_64 \
-  -device virtio-net-pci,netdev=net0 -netdev socket,id=net0,fd=3 \
+qemu-system-x86_64 \
+  -device virtio-net-pci,netdev=net0 \
+  -netdev stream,id=net0,addr.type=unix,addr.path=${HOMEBREW_PREFIX}/var/run/socket_vmnet \
   -m 4096 -accel hvf -cdrom ubuntu-22.04-desktop-amd64.iso
 ```
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -15,9 +15,9 @@ fi
 
 rm -f serial.log
 echo >&2 "===== QEMU BEGIN ====="
-/opt/socket_vmnet/bin/socket_vmnet_client "$SOCKET" qemu-system-x86_64 \
+qemu-system-x86_64 \
 	-device virtio-net-pci,netdev=net0 \
-	-netdev socket,id=net0,fd=3 \
+	-netdev stream,id=net0,addr.type=unix,addr.path="$SOCKET" \
 	-kernel ipxe.lkrn \
 	-initrd test.ipxe \
 	-no-reboot \


### PR DESCRIPTION
Since QEMU 7.2 wrappers are no longer needed[0]; update the
documentation to instruct users to prefer the new options added in
2022[1] but not documented until 2024[2].

The client can be entirely removed in a future release.

[0] https://john-millikin.com/improved-unix-socket-networking-in-qemu-7.2
[1] https://github.com/qemu/qemu/commit/5166fe0ae46dbfed8cd7e7c3743c591ca
[2] https://github.com/qemu/qemu/commit/178413a1031af79f1a224e021e3dfd422
