### PR TITLE
Enable all warnings and pedantic mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GZIP ?= gzip -9 -n
 DIFFOSCOPE ?= diffoscope
 STRIP ?= strip
 
-CFLAGS ?= -O3
+CFLAGS ?= -O3 -Wall -Wextra -pedantic
 ifeq ($(DEBUG),1)
 	CFLAGS += -g
 endif

--- a/cli.c
+++ b/cli.c
@@ -61,7 +61,7 @@ static void print_usage(const char *argv0) {
   printf("version: " VERSION "\n");
 }
 
-static void print_version() { puts(VERSION); }
+static void print_version(void) { puts(VERSION); }
 
 enum {
     CLI_OPT_SOCKET_GROUP = CHAR_MAX + 1,

--- a/main.c
+++ b/main.c
@@ -163,8 +163,9 @@ static void _on_vmnet_packets_available(interface_ref iface, int64_t buf_count,
   for (int i = 0; i < received_count; i++) {
     uint8_t dest_mac[6], src_mac[6];
     assert(pdv[i].vm_pkt_iov[0].iov_len > 12);
-    memcpy(dest_mac, pdv[i].vm_pkt_iov[0].iov_base, sizeof(dest_mac));
-    memcpy(src_mac, pdv[i].vm_pkt_iov[0].iov_base + 6, sizeof(src_mac));
+    const char *packet = (const char *)pdv[i].vm_pkt_iov[0].iov_base;
+    memcpy(dest_mac, packet, sizeof(dest_mac));
+    memcpy(src_mac, packet + 6, sizeof(src_mac));
     DEBUGF("[Handler i=%d] Dest %02X:%02X:%02X:%02X:%02X:%02X, Src "
            "%02X:%02X:%02X:%02X:%02X:%02X,",
            i, dest_mac[0], dest_mac[1], dest_mac[2], dest_mac[3], dest_mac[4],

--- a/main.c
+++ b/main.c
@@ -453,7 +453,7 @@ done:
   if (iface != NULL) {
     stop(&state, iface);
   }
-  if (listen >= 0) {
+  if (listen_fd != -1) {
     close(listen_fd);
   }
   if (pid_fd != -1) {


### PR DESCRIPTION
Using `-Wall -Wextra -pedantic` revealed 2 places we used compiler extensions, and one copy and paste error, comparing function pointer to 0. Fix the code an enable all warnings.

This can be an issue for portable code, but we build for single platform and single compiler, so we should be ok.

Don't treat warnings as errors to reduced the chance that the build will fail on older macOS versions or future versions.