### PR TITLE
CI: remove macos-12; add macos-14-large

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 jobs:
   release:
-    runs-on: macos-12
+    runs-on: macos-15
     # The maximum access is "read" for PRs from public forked repos
     # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,14 @@ jobs:
   integration:
     name: Integration tests
     strategy:
+      fail-fast: false
       matrix:
         # macos-13-large is used as macos-13 seems too flaky.
-        # macos-14 (ARM) cannot be used for the most part of the job
+        # macos-14 (ARM) and later cannot be used for the most part of the job
         # due to the lack of the support for nested virt.
-        platform: [macos-12, macos-13-large]
+        #
+        # TODO: add macos-15-large https://github.com/lima-vm/socket_vmnet/pull/63
+        platform: [macos-13-large, macos-14-large]
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 40
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 # PREFIX should be only writable by the root to avoid privilege escalation with launchd or sudo
 PREFIX ?= /opt/socket_vmnet
 
+# DEBUG=1 is known to break reproducible builds
+DEBUG ?=
+
 export SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct)
 # https://reproducible-builds.org/docs/archives/
 TAR ?= gtar --sort=name --mtime="@$(SOURCE_DATE_EPOCH)" --owner=0 --group=0 --numeric-owner --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime
@@ -11,6 +14,9 @@ DIFFOSCOPE ?= diffoscope
 STRIP ?= strip
 
 CFLAGS ?= -O3
+ifeq ($(DEBUG),1)
+	CFLAGS += -g
+endif
 
 VERSION ?= $(shell git describe --match 'v[0-9]*' --dirty='.m' --always --tags)
 VERSION_TRIMMED := $(VERSION:v%=%)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GZIP ?= gzip -9 -n
 DIFFOSCOPE ?= diffoscope
 STRIP ?= strip
 
-CFLAGS ?= -O3 -g
+CFLAGS ?= -O3
 
 VERSION ?= $(shell git describe --match 'v[0-9]*' --dirty='.m' --always --tags)
 VERSION_TRIMMED := $(VERSION:v%=%)


### PR DESCRIPTION
The macos-12 CI will be completely removed by Dec 3, 2024. (actions/runner-images#10721)