### PR TITLE
Prevent homebrew from upgrading QEMU when installing Lima

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
 # Bridged mode cannot be tested on GHA
       - name: Install Lima
         run: |
-          brew install lima
+          HOMEBREW_NO_INSTALL_UPGRADE=1 brew install lima
           limactl sudoers >etc_sudoers.d_lima
           sudo install -o root etc_sudoers.d_lima "/private/etc/sudoers.d/lima"
       - name: Install the dependencies for the Lima integration test


### PR DESCRIPTION
Trying to fix:

```
==> Installing dependencies for lima: qemu
(https://github.com/lima-vm/socket_vmnet/actions/runs/12017122983/job/33498771215#step:11:15)
Error: qemu is already installed from lima/tap!
```

Not sure why this only happened on `master`, but hopefully this will dissuade brew from installing a newer version of qemu.