### PR TITLE
Revert "CI: add macos-15-large"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,24 +11,18 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: Build
+  integration:
+    name: Integration tests
     strategy:
       fail-fast: false
       matrix:
-        platform: [macos-13, macos-14, macos-15]
+        # macos-13-large is used as macos-13 seems too flaky.
+        # macos-14 (ARM) and later cannot be used for the most part of the job
+        # due to the lack of the support for nested virt.
+        #
+        # TODO: add macos-15-large https://github.com/lima-vm/socket_vmnet/pull/63
+        platform: [macos-13-large, macos-14-large]
     runs-on: ${{ matrix.platform }}
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-        with:
-          fetch-depth: 1
-      - name: Build
-        run: make
-  integration:
-    name: Integration tests
-    # Only a single version of macOS is used for running integration tests, due to the flakiness of the CI.
-    runs-on: macos-15-large  # Intel (supports nested virtualization)
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1


### PR DESCRIPTION
This reverts #63 commit 670aced765263a659eaf8a1f7ab29c3678580271 (ref https://github.com/lima-vm/socket_vmnet/pull/87#issuecomment-2499008033)

Homebrew doesn't seem to manage to build Lima on macos-15.