### PR TITLE
Fix crashes and -p option

### DIFF
--- a/cli.c
+++ b/cli.c
@@ -100,7 +100,7 @@ struct cli_options *cli_options_parse(int argc, char *argv[]) {
       {0, 0, 0, 0},
   };
   int opt = 0;
-  while ((opt = getopt_long(argc, argv, "hvp", longopts, NULL)) != -1) {
+  while ((opt = getopt_long(argc, argv, "hvp:", longopts, NULL)) != -1) {
     switch (opt) {
     case CLI_OPT_SOCKET_GROUP:
       res->socket_group = strdup(optarg);

--- a/main.c
+++ b/main.c
@@ -371,6 +371,9 @@ int main(int argc, char *argv[]) {
   int rc = 1, listen_fd = -1;
   __block interface_ref iface = NULL;
 
+  struct state state;
+  memset(&state, 0, sizeof(state));
+
   struct cli_options *cliopt = cli_options_parse(argc, argv);
   assert(cliopt != NULL);
   if (geteuid() != 0) {
@@ -409,8 +412,6 @@ int main(int argc, char *argv[]) {
     goto done;
   }
 
-  struct state state;
-  memset(&state, 0, sizeof(state));
   state.sem = dispatch_semaphore_create(1);
 
   // Queue for vm connections, allowing processing vms requests in parallel.
@@ -460,8 +461,10 @@ done:
     unlink(cliopt->pidfile);
     close(pid_fd);
   }
-  dispatch_release(state.vms_queue);
-  dispatch_release(state.host_queue);
+  if (state.vms_queue != NULL)
+    dispatch_release(state.vms_queue);
+  if (state.host_queue != NULL)
+    dispatch_release(state.host_queue);
   cli_options_destroy(cliopt);
   return rc;
 }


### PR DESCRIPTION
The -p option was ignoring it's argument.

And when an early error would jump over the initialization of the dispatch queues, then the attempt to release the queues would cause a segmentation violation.

See also #99