### PR TITLE
Fix pidfile cleanup when receiving signal

### DIFF
--- a/main.c
+++ b/main.c
@@ -406,16 +406,6 @@ int main(int argc, char *argv[]) {
     WARN("Seems running with SETUID. This is insecure and highly discouraged: See README.md");
   }
 
-  if (sigsetjmp(jmpbuf, 1) != 0) {
-    goto done;
-  }
-  signal(SIGHUP, signalhandler);
-  signal(SIGINT, signalhandler);
-  signal(SIGTERM, signalhandler);
-
-  // We will receive EPIPE on the socket.
-  signal(SIGPIPE, SIG_IGN);
-
   int pidfile_fd = -1;
   if (cliopt->pidfile != NULL) {
     pidfile_fd = create_pidfile(cliopt->pidfile);
@@ -431,6 +421,16 @@ int main(int argc, char *argv[]) {
     ERRORN("socket_bindlisten");
     goto done;
   }
+
+  if (sigsetjmp(jmpbuf, 1) != 0) {
+    goto done;
+  }
+  signal(SIGHUP, signalhandler);
+  signal(SIGINT, signalhandler);
+  signal(SIGTERM, signalhandler);
+
+  // We will receive EPIPE on the socket.
+  signal(SIGPIPE, SIG_IGN);
 
   state.sem = dispatch_semaphore_create(1);
 

--- a/main.c
+++ b/main.c
@@ -358,7 +358,9 @@ static void remove_pidfile(const char *pidfile)
 {
   if (unlink(pidfile) != 0) {
     ERRORF("Failed to remove pidfile: \"%s\": %s", pidfile, strerror(errno));
+    return;
   }
+  INFOF("Removed pidfile \"%s\" for process %d", pidfile, getpid());
 }
 
 static int create_pidfile(const char *pidfile)
@@ -385,6 +387,7 @@ static int create_pidfile(const char *pidfile)
     return -1;
   }
 
+  INFOF("Created pidfile \"%s\" for process %d", pidfile, getpid());
   return fd;
 }
 


### PR DESCRIPTION
When not using --pidfile option, pidfile_fd is initialized to -1. However if we are interrupted by signal, when we check the value during cleanup, the value is 0(!) and we try to delete a null pidfile and log this error:

    ^CINFO | Received signal: Interrupt: 2
    ERROR| Failed to remove pidfile: "(null)": Bad address

This does not make sense, but we use sigsetjmp(3) for handling signals and its manual mentions:

    The sigsetjmp()/siglongjmp() function pairs save and restore the
    signal mask if the argument savemask is non-zero; otherwise, only
    the register set and the stack are saved.

It seems that pidfile_fd is restored to the value at the time sigsetjmp() was called, which may be 0 (or any other value on the stack). I think this is an old bug, exposed by logging an error when unlink() fails.

Fix by creating the pidfile and binding listen_fd before calling sigsetjmp().  When sigsetjmp() restores the stack the value of pidfile_fd and listen_fd are not affected.