### PR TITLE
Handle signals with kqueue

### DIFF
--- a/main.c
+++ b/main.c
@@ -395,7 +395,9 @@ static void on_accept(struct state *state, int accept_fd, interface_ref iface);
 
 int main(int argc, char *argv[]) {
   debug = getenv("DEBUG") != NULL;
-  int rc = 1, listen_fd = -1;
+  int rc = 1;
+  int listen_fd = -1;
+  int pidfile_fd = -1;
   __block interface_ref iface = NULL;
 
   struct state state = {0};
@@ -409,7 +411,6 @@ int main(int argc, char *argv[]) {
     WARN("Seems running with SETUID. This is insecure and highly discouraged: See README.md");
   }
 
-  int pidfile_fd = -1;
   if (cliopt->pidfile != NULL) {
     pidfile_fd = create_pidfile(cliopt->pidfile);
     if (pidfile_fd == -1) {


### PR DESCRIPTION
We used sigsetjmp() and siglogjmp() for signal handling, which is very                                                 
hard to use correctly and too magical. Replace it with the kqueue(),
which can notify events on sockets and signals.

The get signals with kqueue, we need to block them. This has the nice
property that no function in any thread will fail with EINTR when we
receive a signal, which simplifies the code.

We setup signal handling before we open the pidfile, so receiving a
signal after the pidfile was created will always remove the pidfile.
Before this change we has a small window when receiving a signal would
terminate the process without removing the pidfile.

To wait for connection or signal, we wait for kqueue events. If we
receiving a signal we break the loop and exit normally, since
termination by signal is normal. This can help programs running
socket_vment that may be confused by exit code 1.

Notes:

- Keeping listen_fd in blocking mode to simplify the code. accept()
  should not block when we receive a EVFILT_READ event. We can change to
  non-blocking mode later if this assumption is wrong.
