### PR TITLE
Update performance tests

### DIFF
--- a/test/lima.yaml
+++ b/test/lima.yaml
@@ -1,7 +1,7 @@
 images:
-- location: "https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-amd64.img"
+- location: "https://cloud-images.ubuntu.com/releases/24.10/release/ubuntu-24.10-server-cloudimg-amd64.img"
   arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-arm64.img"
+- location: "https://cloud-images.ubuntu.com/releases/24.10/release/ubuntu-24.10-server-cloudimg-arm64.img"
   arch: "aarch64"
 cpus: 2
 memory: "2g"

--- a/test/perf.sh
+++ b/test/perf.sh
@@ -17,7 +17,7 @@ create() {
 host-to-vm() {
     limactl start server
     nohup limactl shell server iperf3 --server --daemon
-    iperf3-darwin --client $(server_address) --length 1m --time $TIME
+    iperf3-darwin --client $(server_address) --time $TIME
     limactl stop server
 }
 
@@ -26,7 +26,7 @@ host-to-vm-2() {
     limactl start client &
     wait
     nohup limactl shell server iperf3 --server --daemon
-    iperf3-darwin --client $(server_address) --length 1m --time $TIME
+    iperf3-darwin --client $(server_address) --time $TIME
     limactl stop server
     limactl stop client
 }


### PR DESCRIPTION
- Use latest ubuntu image matching lima default image
- Simplify iperf3 command, focusing on more recent hardware