### PR TITLE
Use standard runner for the lima integration test

### DIFF
--- a/.github/workflows/lima.yaml
+++ b/.github/workflows/lima.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - macos-15-large  # Intel
+          - macos-13  # Intel
     runs-on: ${{ matrix.platform }}
     # Typically takes 8 minutes. If a step get stuck for many mintues it is
     # unlikely to succeed.
@@ -48,10 +48,6 @@ jobs:
           make ARCH=arm64
           sudo make PREFIX=/opt/socket_vmnet.arm64 install.bin install.doc
           if file /opt/socket_vmnet.arm64/bin/* | grep -q x86_64 ; then false ; fi
-      - name: Update brew (macos-15-large)
-        if: matrix.platform == 'macos-15-large'
-        # Without this we get lima 0.23.2 instead of latest release.
-        run: brew update
       - name: Install Lima
         run: |
           brew install lima

--- a/test/vmnet.yaml
+++ b/test/vmnet.yaml
@@ -1,18 +1,8 @@
-# Forked from https://github.com/lima-vm/lima/blob/v0.23.2/examples/vmnet.yaml
-#
-# `no_timer_check` is injected to the kernel cmdline, as a workaround to https://github.com/lima-vm/lima/issues/84
+# Minimal vm for testing socket_vmnet integartion with lima.
 
 images:
-- location: "https://cloud-images.ubuntu.com/releases/24.04/release-20240821/ubuntu-24.04-server-cloudimg-amd64.img"
+- location: "https://cloud-images.ubuntu.com/releases/24.10/release/ubuntu-24.10-server-cloudimg-amd64.img"
   arch: "x86_64"
-  digest: "sha256:0e25ca6ee9f08ec5d4f9910054b66ae7163c6152e81a3e67689d89bd6e4dfa69"
-  kernel:
-    location: https://cloud-images.ubuntu.com/releases/24.04/release-20240821/unpacked/ubuntu-24.04-server-cloudimg-amd64-vmlinuz-generic
-    digest: sha256:1e894dc26a939a7cb408ba8366e101f5572a5f85a90a6d74ab4cb55211460306
-    cmdline: root=LABEL=cloudimg-rootfs ro console=tty1 console=ttyAMA0 no_timer_check
-  initrd:
-    location: https://cloud-images.ubuntu.com/releases/24.04/release-20240821/unpacked/ubuntu-24.04-server-cloudimg-amd64-initrd-generic
-    digest: sha256:c44215c42d97abd9ada4a961de0ab7305d74c39860776cf2d7a0260ac9d0637e
 plain: true
 memory: "1g"
 cpus: 1


### PR DESCRIPTION
Testing with vfkit shows that standard runner is stable for running
small vm, so it should work for lima. Lets try to use standard Intel
runner to avoid unnecessary cost.