### PR TITLE
More performance tests tweaks

### DIFF
--- a/test/lima.yaml
+++ b/test/lima.yaml
@@ -3,7 +3,7 @@ images:
   arch: "x86_64"
 - location: "https://cloud-images.ubuntu.com/releases/24.10/release/ubuntu-24.10-server-cloudimg-arm64.img"
   arch: "aarch64"
-cpus: 2
+cpus: 1
 memory: "2g"
 plain: true
 networks:

--- a/test/perf.sh
+++ b/test/perf.sh
@@ -16,7 +16,7 @@ create() {
 
 host-to-vm() {
     limactl start server
-    nohup limactl shell server iperf3 --server --daemon
+    limactl shell server sudo systemctl start iperf3.service
     iperf3-darwin --client $(server_address) --time $TIME
     limactl stop server
 }
@@ -25,7 +25,7 @@ host-to-vm-2() {
     limactl start server &
     limactl start client &
     wait
-    nohup limactl shell server iperf3 --server --daemon
+    limactl shell server sudo systemctl start iperf3.service
     iperf3-darwin --client $(server_address) --time $TIME
     limactl stop server
     limactl stop client
@@ -35,7 +35,7 @@ vm-to-vm() {
     limactl start server &
     limactl start client &
     wait
-    nohup limactl shell server iperf3 --server --daemon
+    limactl shell server sudo systemctl start iperf3.service
     addr=$(server_address)
     limactl shell client iperf3 --client $addr --length 1m --time $TIME
     limactl stop server

--- a/test/perf.sh
+++ b/test/perf.sh
@@ -37,7 +37,7 @@ vm-to-vm() {
     wait
     limactl shell server sudo systemctl start iperf3.service
     addr=$(server_address)
-    limactl shell client iperf3 --client $addr --length 1m --time $TIME
+    limactl shell client iperf3 --client $addr --time $TIME
     limactl stop server
     limactl stop client
 }


### PR DESCRIPTION
- Use vms with 1 cpu for faster and more consistent results
- Use iperf3.service in server vm
- Remove leftover --length argument