### PR TITLE
Improve performance test

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,80 @@
+# Testing socket_vmnet
+
+## Performance testing
+
+You can run performance tests using the perf.sh script.
+
+```console
+% test/perf.sh
+Usage test/perf.sh command [options]
+
+Commands:
+  create          create test vms
+  delete          delete test vms
+  run             run benchmarks
+
+Options:
+  -c COUNT        number of vms
+  -t SECONDS      time in seconds to transmit for (default 30)
+  -v VM_TYPE      lima vmType [vz, qemu] (default vz)
+  -b IFACE        if set, use lima bridged network with IFACE
+  -o OUT_DIR      output directory (default perf.out)
+```
+
+### Example run
+
+Create test vms:
+
+```console
+test/perf.sh create -c 3 2>perf.log
+```
+
+Run all tests with shared and bridged modes, vz and qemu vm type,
+using 1, 2, and 3 vms:
+
+```
+for v in vz qemu; do
+    for c in $(seq 3); do
+        test/perf.sh run -c $c -v $v 2>>perf.log
+        test/perf.sh run -c $c -v $v -b en10 2>>perf.log
+    done
+done
+```
+
+Delete the test vms:
+
+```console
+test/perf.sh delete -c 3 2>>perf.log
+```
+
+This creates the following results:
+
+```console
+% tree test/perf.out
+test/perf.out
+├── bridged-qemu-1
+│   ├── host-to-vm.json
+│   └── vm-to-host.json
+├── bridged-qemu-2
+│   ├── host-to-vm.json
+│   ├── vm-to-host.json
+│   └── vm-to-vm.json
+├── bridged-qemu-3
+│   ├── host-to-vm.json
+│   ├── vm-to-host.json
+│   └── vm-to-vm.json
+...
+```
+
+You can create reports like this:
+
+```console
+% for c in 1 2 3; do
+    result="test/perf.out/shared-vz-$c/host-to-vm.json"
+    gbits_per_second=$(jq -r '.end.sum_received.bits_per_second / 1000000000' < "$result")
+    printf "%d vms: %.2f Gbits/s\n" $c $gbits_per_second
+done
+1 vms: 2.35 Gbits/s
+2 vms: 1.83 Gbits/s
+3 vms: 1.15 Gbits/s
+```

--- a/test/lima.yaml
+++ b/test/lima.yaml
@@ -4,7 +4,7 @@ images:
 - location: "https://cloud-images.ubuntu.com/releases/24.10/release/ubuntu-24.10-server-cloudimg-arm64.img"
   arch: "aarch64"
 cpus: 1
-memory: "2g"
+memory: "1g"
 plain: true
 networks:
 - socket: /var/run/socket_vmnet

--- a/test/perf.sh
+++ b/test/perf.sh
@@ -1,76 +1,152 @@
 #!/bin/bash
+
 set -e
+set -o pipefail
+
 cd "$(dirname "$0")"
 
-TIME=${2:-30}
-
 server_address() {
-    limactl shell server ip -j -4 addr show dev lima0 | jq -r '.[0].addr_info[0].local'
+    limactl shell perf1 ip -j -4 addr show dev lima0 | jq -r '.[0].addr_info[0].local'
 }
 
 create() {
-    limactl create --name server --tty=false lima.yaml &
-    limactl create --name client --tty=false lima.yaml &
+    echo "[perf] Creating $count vms"
+    for i in $(seq $count); do
+        limactl create --name perf$i --tty=false lima.yaml &
+    done
     wait
-}
-
-host-to-vm() {
-    limactl start server
-    limactl shell server sudo systemctl start iperf3.service
-    iperf3-darwin --client $(server_address) --time $TIME
-    limactl stop server
-}
-
-host-to-vm-2() {
-    limactl start server &
-    limactl start client &
-    wait
-    limactl shell server sudo systemctl start iperf3.service
-    iperf3-darwin --client $(server_address) --time $TIME
-    limactl stop server
-    limactl stop client
-}
-
-vm-to-vm() {
-    limactl start server &
-    limactl start client &
-    wait
-    limactl shell server sudo systemctl start iperf3.service
-    addr=$(server_address)
-    limactl shell client iperf3 --client $addr --time $TIME
-    limactl stop server
-    limactl stop client
 }
 
 delete() {
-    limactl delete -f server
-    limactl delete -f client
+    echo "[perf] Delete $count vms"
+    for i in $(seq $count); do
+        limactl delete -f perf$i
+    done
 }
 
+run() {
+    echo "[perf] Updating vms"
+    update_vms
+
+    echo "[perf] Starting vms"
+    start_vms
+
+    echo "[perf] Starting iperf3 service"
+    limactl shell perf1 sudo systemctl start iperf3.service >>perf.log
+
+    config="$out_dir/$mode-$vm_type-$count"
+    mkdir -p "$config"
+    addr=$(server_address)
+
+    echo "[perf] Running $config/host-to-vm"
+    iperf3-darwin --client $addr --time $time --json > "$config/host-to-vm.json"
+
+    echo "[perf] Running $config/vm-to-host"
+    iperf3-darwin --client $addr --time $time --reverse --json > "$config/vm-to-host.json"
+
+    if [ $count -gt 1 ]; then
+        echo "[perf] Running $config/vm-to-vm"
+        limactl shell perf2 iperf3 --client $addr --time $time --json > "$config/vm-to-vm.json"
+    fi
+
+    echo "[perf] Stopping vms"
+    stop_vms
+}
+
+update_vms() {
+    socket="/var/run/socket_vmnet"
+    if [ "$mode" = "bridged" ]; then
+        socket+=".bridged.$iface"
+    fi
+    for i in $(seq $count); do
+        limactl edit perf$i --tty=false \
+            --set ".vmType = \"$vm_type\" | .networks[0].socket = \"$socket\""
+    done
+}
+
+start_vms() {
+    for i in $(seq $count); do
+        limactl start perf$i &
+    done
+    wait
+}
+
+stop_vms() {
+    for i in $(seq $count); do
+        limactl stop perf$i
+    done
+}
+
+usage() {
+    echo "Usage $0 command [options]"
+    echo
+    echo "Commands:"
+    echo "  create          create test vms"
+    echo "  delete          delete test vms"
+    echo "  run             run benchmarks"
+    echo
+    echo "Options:"
+    echo "  -c COUNT        number of vms"
+    echo "  -t SECONDS      time in seconds to transmit for (default 30)"
+    echo "  -v VM_TYPE      lima vmType [vz, qemu] (default vz)"
+    echo "  -b IFACE        if set, use lima bridged network with IFACE"
+    echo "  -o OUT_DIR      output directory (default perf.out)"
+}
+
+# Defaults
+count=2
+time=30
+vm_type=vz
+mode=shared
+iface=
+out_dir=perf.out
+
 case $1 in
-create)
-    create
-    ;;
-host-to-vm)
-    host-to-vm
-    ;;
-host-to-vm-2)
-    host-to-vm-2
-    ;;
-vm-to-vm)
-    vm-to-vm
-    ;;
-delete)
-    delete
+create|delete|run)
+    command=$1
+    shift
     ;;
 *)
-    echo "Usage $0 command"
-    echo
-    echo "Available commands:"
-    echo "  create                  create test vms"
-    echo "  delete                  delete test vms"
-    echo "  host-to-vm [TIME]       test host to vm performance"
-    echo "  host-to-vm-2 [TIME]     test host to vm performance with 1 extra vm"
-    echo "  vm-to-vm [TIME]         test vm to vm performance"
+    usage
+    exit 1
     ;;
 esac
+
+args=$(getopt c:t:v:b:o: $*)
+if [ $? -ne 0 ]; then
+    usage
+    exit 1
+fi
+
+set -- $args
+
+while :; do
+    case $1 in
+    -c)
+        count=$2
+        shift; shift
+        ;;
+    -t)
+        time=$2
+        shift; shift
+        ;;
+    -v)
+        vm_type="$2"
+        shift; shift
+        ;;
+    -b)
+        mode=bridged
+        iface="$2"
+        shift; shift
+        ;;
+    -o)
+        out_dir="$2"
+        shift; shift
+        ;;
+    --)
+        shift; break;
+        ;;
+    esac
+done
+
+$command


### PR DESCRIPTION
Improve performance test                                                                                                       

- Create N vms (default 2) to allow testing scaling issues
- Run tests with N vms (default 2)
- Run all tests with same vms, instead of starting an stopping the vms 
  for each test
- Add vm-to-host test (iperf3 -c server --reverse)
- Add -v option to set the vm type
- Add -b option to test bridged mode
- Store test results in JSON format
- Add command line options instead of positional arguments
- Rename to vms so they are less likely to clash with real vms 
- Minimize vm memory
- Improve logging
- Add test/README.md documenting perf.sh usage