### PR TITLE
markdown linting added

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,3 +30,10 @@ jobs:
           fetch-depth: 1
       - name: Build
         run: make
+      - name: Run markdownlint with auto-fix
+        uses: DavidAnson/markdownlint-cli2-action@05f32210e84442804257b2a6f20b273450ec8265 #v19
+        with:
+          fix: true # Enabled to improve reported errors
+          globs: '**/*.md'
+          config: '.markdownlint.json'
+          

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+  "MD013": false,
+  "MD033": false
+}

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ as non-DHCP static addresses.
 
 - Create `/etc/bootptab` like this. Make sure not to drop the "%%" header.
 
-```
+```bash
 # bootptab
 %%
 # hostname      hwtype  hwaddr              ipaddr          bootfile
@@ -411,7 +411,7 @@ tmp-vm01        1       de:ad:be:ef:00:01   192.168.105.100
 
 - Reload the DHCP daemon.
 
-```
+```bash
 sudo /bin/launchctl kickstart -kp system/com.apple.bootpd
 ```
 

--- a/test/README.md
+++ b/test/README.md
@@ -32,7 +32,7 @@ test/perf.sh create -c 3 2>perf.log
 Run all tests with shared and bridged modes, vz and qemu vm type,
 using 1, 2, and 3 vms:
 
-```
+```bash
 for v in vz qemu; do
     for c in $(seq 3); do
         test/perf.sh run -c $c -v $v 2>>perf.log


### PR DESCRIPTION
Fixes  #79  
added the linting according to the rules discussed 
in `json` 
```bash
{
  "MD013": false,
  "MD033": false
}
```