### PR TITLE
Update test vms to Ubuntu 25.04

### DIFF
--- a/test/lima.yaml
+++ b/test/lima.yaml
@@ -1,7 +1,7 @@
 images:
-- location: "https://cloud-images.ubuntu.com/releases/24.10/release/ubuntu-24.10-server-cloudimg-amd64.img"
+- location: "https://cloud-images.ubuntu.com/releases/25.04/release/ubuntu-25.04-server-cloudimg-amd64.img"
   arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/releases/24.10/release/ubuntu-24.10-server-cloudimg-arm64.img"
+- location: "https://cloud-images.ubuntu.com/releases/25.04/release/ubuntu-25.04-server-cloudimg-arm64.img"
   arch: "aarch64"
 cpus: 1
 memory: "1g"

--- a/test/vmnet.yaml
+++ b/test/vmnet.yaml
@@ -1,7 +1,7 @@
 # Minimal vm for testing socket_vmnet integartion with lima.
 
 images:
-- location: "https://cloud-images.ubuntu.com/releases/24.10/release/ubuntu-24.10-server-cloudimg-amd64.img"
+- location: "https://cloud-images.ubuntu.com/releases/25.04/release/ubuntu-25.04-server-cloudimg-amd64.img"
   arch: "x86_64"
 plain: true
 memory: "1g"


### PR DESCRIPTION
Since Sep 13 updating the vms fail with:

    Ign:1 http://archive.ubuntu.com/ubuntu oracular InRelease
    Ign:2 http://security.ubuntu.com/ubuntu oracular-security InRelease
    Ign:3 http://archive.ubuntu.com/ubuntu oracular-updates InRelease
    Err:4 http://security.ubuntu.com/ubuntu oracular-security Release
      404  Not Found [IP: 91.189.91.83 80]
    Ign:5 http://archive.ubuntu.com/ubuntu oracular-backports InRelease
    Err:6 http://archive.ubuntu.com/ubuntu oracular Release
      404  Not Found [IP: 91.189.91.83 80]
    Err:7 http://archive.ubuntu.com/ubuntu oracular-updates Release
      404  Not Found [IP: 91.189.91.83 80]
    Err:8 http://archive.ubuntu.com/ubuntu oracular-backports Release
      404  Not Found [IP: 91.189.91.83 80]
    Reading package lists...
    E: The repository 'http://security.ubuntu.com/ubuntu oracular-security Release' no longer has a Release file.
    E: The repository 'http://archive.ubuntu.com/ubuntu oracular Release' no longer has a Release file.
    E: The repository 'http://archive.ubuntu.com/ubuntu oracular-updates Release' no longer has a Release file.
    E: The repository 'http://archive.ubuntu.com/ubuntu oracular-backports Release' does not have a Release file.