### PR TITLE
docs: split From binary install steps into copy-paste-friendly blocks (#96)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,20 +43,34 @@ Requires macOS 10.15 or later.
 
 ### From binary
 
+Get the latest release version:
+
 ```bash
 VERSION="$(curl -fsSL https://api.github.com/repos/lima-vm/socket_vmnet/releases/latest | jq -r .tag_name)"
 FILE="socket_vmnet-${VERSION:1}-$(uname -m).tar.gz"
+```
 
-# Download the binary archive
+Download the binary archive:
+
+```bash
 curl -OSL "https://github.com/lima-vm/socket_vmnet/releases/download/${VERSION}/${FILE}"
+```
 
-# (Optional) Attest the GitHub Artifact Attestation using GitHub's gh command (https://cli.github.com)
+(Optional) Attest the GitHub Artifact Attestation using GitHub's [`gh`](https://cli.github.com) command:
+
+```bash
 gh attestation verify --owner=lima-vm "${FILE}"
+```
 
-# (Optional) Preview the contents of the binary archive
+(Optional) Preview the contents of the binary archive:
+
+```bash
 tar tzvf "${FILE}"
+```
 
-# Install /opt/socket_vmnet from the binary archive
+Install `/opt/socket_vmnet` from the binary archive:
+
+```bash
 sudo tar Cxzvf / "${FILE}" opt/socket_vmnet
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Requires macOS 10.15 or later.
 ### From binary
 
 ```bash
+[ -n "$ZSH_VERSION" ] && setopt interactive_comments
+
 VERSION="$(curl -fsSL https://api.github.com/repos/lima-vm/socket_vmnet/releases/latest | jq -r .tag_name)"
 FILE="socket_vmnet-${VERSION:1}-$(uname -m).tar.gz"
 


### PR DESCRIPTION
Fixes #96.

## What changed

The "From binary" install snippet in the README was one bash block that interleaved commands with `# ...` comments. Split it into separate blocks per step, with the explanatory text moved out into surrounding prose.

## Why this matters

Interactive zsh does not treat `#` as a comment unless the user has run `setopt interactivecomments`. Pasting the original block into a default-config zsh produces:

```
quote>
```

…stuck on the unmatched apostrophe in `# (Optional) Attest the GitHub Artifact Attestation using GitHub's gh command (...)`. The issue reproduced this exactly.

The format used here matches the proposal from #96 that @jandubois agreed to ("Works for me. It requires a bunch of clicking and pasting instead of copying it all at once, but I think that is fine."). Each step now stands as its own copy-pasteable block, and the comments become regular prose so they render normally instead of being inside the code fence.

## Verification

- All commands are unchanged; only the surrounding prose / fencing was edited.
- Total ```` ``` ```` fence count is even (verified post-edit).
- The two `(Optional)` steps are still clearly marked as optional.