### PR TITLE
docs: add Tart to Usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Unlike `vde_vmnet`, `socket_vmnet` does not depend on VDE.
   - [Usage](#usage)
     - [QEMU](#qemu)
     - [Lima](#lima)
+    - [Tart](#tart)
   - [Advanced usage](#advanced-usage)
     - [Multi VM](#multi-vm)
     - [Bridged mode](#bridged-mode)
@@ -316,6 +317,12 @@ $ limactl start --name=default template://vmnet
 ```
 
 See also https://github.com/lima-vm/lima/blob/master/docs/network.md
+
+### Tart
+
+[Tart](https://github.com/cirruslabs/tart) (which uses Apple's `Virtualization.framework` rather than QEMU) can connect to a `socket_vmnet` daemon via a small drop-in replacement for Tart's own `softnet` network helper. With it, Tart VMs share L2 with Lima VMs on the same daemon's network, restoring VM↔VM connectivity that is otherwise blocked on macOS Sequoia/Tahoe by the kernel `PRIVATE` flag on `bridge100` member interfaces.
+
+See [tannevaled/socket-vmnet-shim](https://github.com/tannevaled/socket-vmnet-shim) — implements the SOCK_DGRAM↔SOCK_STREAM framing translation discussed in [#13](https://github.com/lima-vm/socket_vmnet/issues/13).
 
 ## Advanced usage
 


### PR DESCRIPTION
## Summary

Adds a `### Tart` subsection under `## Usage`, alongside the existing QEMU and Lima sections, pointing readers to a drop-in `softnet` replacement that lets [Tart](https://github.com/cirruslabs/tart) VMs share a `socket_vmnet` daemon with Lima VMs.

## Context

This implements (out-of-tree, as a sidecar binary) the SOCK_DGRAM↔SOCK_STREAM framing pipe that @balajiv113 proposed in #13 and @AkihiroSuda accepted as a reasonable workaround:

> What if we write a Pipe mechanism to translate vz packets to qemu like packets ?? If we do this, we don't need any changes in socket_vmnet / gvisor. […] 1. Dial to a unix sock and get conn / 2. create sock pair for dgram / 3. read from dgram and write to unix sock with header / 4. read from unix sock and write to dgram without header
> — [#13 (comment)](https://github.com/lima-vm/socket_vmnet/issues/13#issuecomment-1366410910)

The standalone implementation lives at https://github.com/tannevaled/socket-vmnet-shim — ~200 lines of std-only Rust, two threads, ~300 KB binary stripped. It impersonates cirruslabs/softnet's CLI so \`tart run --net-softnet <vm>\` picks it up unmodified via PATH override. Verified on macOS Tahoe 26.5 with 3 Tart Debian VMs and 3 Lima Debian VMs on the same socket_vmnet shared daemon — full mesh ping, 0% loss.

This PR is just the documentation entry that makes the path discoverable to socket_vmnet users; it intentionally doesn't pull the shim into this repo (the maintenance footprint stays elsewhere unless you'd prefer otherwise — happy to do that as a follow-up if it's of interest).

## Test plan

- [x] Read the rendered README in the diff to confirm the new subsection sits naturally between Lima and Advanced usage
- [x] TOC anchor [Tart](#tart) resolves to the new heading
- [ ] If/when doctoc is re-run, the auto-generated entry will match (I added it manually for now to stay accurate)